### PR TITLE
Added fat pointers to state machines

### DIFF
--- a/src/Kinetic.Avalonia/KineticBinding.cs
+++ b/src/Kinetic.Avalonia/KineticBinding.cs
@@ -176,6 +176,12 @@ public abstract class KineticBinding : IBinding
         public StateMachineBox Box =>
             (StateMachineBox) (_box ?? throw new InvalidOperationException());
 
+        public StateMachine<TProperty> Reference =>
+            new StateMachine<TProperty, PublishStateMachine<TProperty>>(ref this);
+
+        public StateMachine? Continuation =>
+            null;
+
         public void Initialize(StateMachineBox box) =>
             _box = (IBox) box;
 
@@ -212,6 +218,24 @@ public abstract class KineticBinding : IBinding
 
         public StateMachineBox Box =>
             _continuation.Box;
+
+        StateMachine<Property<TProperty>?> IStateMachine<Property<TProperty>?>.Reference =>
+            new StateMachine<Property<TProperty>?, PropertyStateMachine<TContinuation, TProperty>>(ref this);
+
+        StateMachine<ReadOnlyProperty<TProperty>?> IStateMachine<ReadOnlyProperty<TProperty>?>.Reference =>
+            new StateMachine<ReadOnlyProperty<TProperty>?, PropertyStateMachine<TContinuation, TProperty>>(ref this);
+
+        StateMachine<TProperty> IStateMachine<TProperty>.Reference =>
+            new StateMachine<TProperty, PropertyStateMachine<TContinuation, TProperty>>(ref this);
+
+        StateMachine? IStateMachine<Property<TProperty>?>.Continuation =>
+            _continuation.Reference;
+
+        StateMachine? IStateMachine<ReadOnlyProperty<TProperty>?>.Continuation =>
+            _continuation.Reference;
+
+        StateMachine? IStateMachine<TProperty>.Continuation =>
+            null;
 
         public void Initialize(StateMachineBox box)
         {
@@ -297,6 +321,18 @@ public abstract class KineticBinding : IBinding
 
         public StateMachineBox Box =>
             _continuation.Box;
+
+        StateMachine<ObservableList<TElement>?> IStateMachine<ObservableList<TElement>?>.Reference =>
+            new StateMachine<ObservableList<TElement>?, ListStateMachine<TElement, TContinuation>>(ref this);
+
+        StateMachine<ReadOnlyObservableList<TElement>?> IStateMachine<ReadOnlyObservableList<TElement>?>.Reference =>
+            new StateMachine<ReadOnlyObservableList<TElement>?, ListStateMachine<TElement, TContinuation>>(ref this);
+
+        StateMachine? IStateMachine<ObservableList<TElement>?>.Continuation =>
+            _continuation.Reference;
+
+        StateMachine? IStateMachine<ReadOnlyObservableList<TElement>?>.Continuation =>
+            _continuation.Reference;
 
         public void Initialize(StateMachineBox box) =>
             _continuation.Initialize(box);

--- a/src/Kinetic.Avalonia/KineticBindingPath.cs
+++ b/src/Kinetic.Avalonia/KineticBindingPath.cs
@@ -25,9 +25,9 @@ public static class KineticBindingPath
     public static ObserverBuilder<ReadOnlyProperty<TResult>?> Property<TSource, TResult>(this ObserverBuilder<ReadOnlyProperty<TSource>?> source, Func<TSource?, ReadOnlyProperty<TResult>?> selector) =>
         source.ContinueWith<PropertyStateMachineFactory<TSource>, TSource?>(default).Property(selector);
 
-    private struct PropertyStateMachineFactory<TSource>
-        : IStateMachineFactory<Property<TSource>?, TSource?>
-        , IStateMachineFactory<ReadOnlyProperty<TSource>?, TSource?>
+    private struct PropertyStateMachineFactory<TSource> :
+        IStateMachineFactory<Property<TSource>?, TSource?>,
+        IStateMachineFactory<ReadOnlyProperty<TSource>?, TSource?>
     {
         public void Create<TContinuation>(in TContinuation continuation, ObserverStateMachine<Property<TSource>?> source)
             where TContinuation : struct, IStateMachine<TSource?>
@@ -42,10 +42,10 @@ public static class KineticBindingPath
         }
     }
 
-    private struct PropertyStateMachine<TContinuation, TSource>
-        : IStateMachine<Property<TSource>?>
-        , IStateMachine<ReadOnlyProperty<TSource>?>
-        , IStateMachine<TSource>
+    private struct PropertyStateMachine<TContinuation, TSource> :
+        IStateMachine<Property<TSource>?>,
+        IStateMachine<ReadOnlyProperty<TSource>?>,
+        IStateMachine<TSource>
         where TContinuation : struct, IStateMachine<TSource?>
     {
         private TContinuation _continuation;
@@ -56,6 +56,24 @@ public static class KineticBindingPath
 
         public StateMachineBox Box =>
             _continuation.Box;
+
+        StateMachine<Property<TSource>?> IStateMachine<Property<TSource>?>.Reference =>
+            new StateMachine<Property<TSource>?, PropertyStateMachine<TContinuation, TSource>>(ref this);
+
+        StateMachine<ReadOnlyProperty<TSource>?> IStateMachine<ReadOnlyProperty<TSource>?>.Reference =>
+            new StateMachine<ReadOnlyProperty<TSource>?, PropertyStateMachine<TContinuation, TSource>>(ref this);
+
+        StateMachine<TSource> IStateMachine<TSource>.Reference =>
+            new StateMachine<TSource, PropertyStateMachine<TContinuation, TSource>>(ref this);
+
+        StateMachine? IStateMachine<Property<TSource>?>.Continuation =>
+            _continuation.Reference;
+
+        StateMachine? IStateMachine<ReadOnlyProperty<TSource>?>.Continuation =>
+            _continuation.Reference;
+
+        StateMachine? IStateMachine<TSource>.Continuation =>
+            null;
 
         public void Initialize(StateMachineBox box) =>
             _continuation.Initialize(box);

--- a/src/Kinetic.Avalonia/Observable.ContinueOn.cs
+++ b/src/Kinetic.Avalonia/Observable.ContinueOn.cs
@@ -53,6 +53,12 @@ public static class Observable
         public StateMachineBox Box =>
             _continuation.Box;
 
+        public StateMachine<TSource> Reference =>
+            new StateMachine<TSource, ContinueOnDispatcherStateMachine<TContinuation, TSource>>(ref this);
+
+        public StateMachine? Continuation =>
+            _continuation.Reference;
+
         public void Initialize(StateMachineBox box) =>
             _continuation.Initialize(box);
 

--- a/src/Kinetic/Linq/Observable.All.cs
+++ b/src/Kinetic/Linq/Observable.All.cs
@@ -37,6 +37,12 @@ public static partial class Observable
         public StateMachineBox Box =>
             _continuation.Box;
 
+        public StateMachine<bool> Reference =>
+            StateMachine<bool>.Create(ref this);
+
+        public StateMachine? Continuation =>
+            _continuation.Reference;
+
         public void Initialize(StateMachineBox box) =>
             _continuation.Initialize(box);
 

--- a/src/Kinetic/Linq/Observable.Any.cs
+++ b/src/Kinetic/Linq/Observable.Any.cs
@@ -22,11 +22,11 @@ public static partial class Observable
         public void Create<TContinuation>(in TContinuation continuation, ObserverStateMachine<TSource> source)
             where TContinuation : struct, IStateMachine<bool>
         {
-            source.ContinueWith(new AnyStateMachine<TContinuation, TSource>(continuation));
+            source.ContinueWith(new AnyStateMachine<TSource, TContinuation>(continuation));
         }
     }
 
-    private struct AnyStateMachine<TContinuation, TSource> : IStateMachine<TSource>
+    private struct AnyStateMachine<TSource, TContinuation> : IStateMachine<TSource>
         where TContinuation : struct, IStateMachine<bool>
     {
         private TContinuation _continuation;

--- a/src/Kinetic/Linq/Observable.Any.cs
+++ b/src/Kinetic/Linq/Observable.Any.cs
@@ -37,6 +37,12 @@ public static partial class Observable
         public StateMachineBox Box =>
             _continuation.Box;
 
+        public StateMachine<TSource> Reference =>
+            StateMachine<TSource>.Create(ref this);
+
+        public StateMachine? Continuation =>
+            _continuation.Reference;
+
         public void Initialize(StateMachineBox box) =>
             _continuation.Initialize(box);
 

--- a/src/Kinetic/Linq/Observable.Contains.cs
+++ b/src/Kinetic/Linq/Observable.Contains.cs
@@ -26,11 +26,11 @@ public static partial class Observable
         public void Create<TContinuation>(in TContinuation continuation, ObserverStateMachine<TSource> source)
             where TContinuation : struct, IStateMachine<bool>
         {
-            source.ContinueWith(new ContainsStateMachine<TContinuation, TSource>(continuation, _value, _comparer));
+            source.ContinueWith(new ContainsStateMachine<TSource, TContinuation>(continuation, _value, _comparer));
         }
     }
 
-    private struct ContainsStateMachine<TContinuation, TSource> : IStateMachine<TSource>
+    private struct ContainsStateMachine<TSource, TContinuation> : IStateMachine<TSource>
         where TContinuation : struct, IStateMachine<bool>
     {
         private TContinuation _continuation;

--- a/src/Kinetic/Linq/Observable.Contains.cs
+++ b/src/Kinetic/Linq/Observable.Contains.cs
@@ -47,6 +47,12 @@ public static partial class Observable
         public StateMachineBox Box =>
             _continuation.Box;
 
+        public StateMachine<TSource> Reference =>
+            StateMachine<TSource>.Create(ref this);
+
+        public StateMachine? Continuation =>
+            _continuation.Reference;
+
         public void Initialize(StateMachineBox box) =>
             _continuation.Initialize(box);
 

--- a/src/Kinetic/Linq/Observable.Count.cs
+++ b/src/Kinetic/Linq/Observable.Count.cs
@@ -41,6 +41,12 @@ public static partial class Observable
         public StateMachineBox Box =>
             _continuation.Box;
 
+        public StateMachine<TSource> Reference =>
+            StateMachine<TSource>.Create(ref this);
+
+        public StateMachine? Continuation =>
+            _continuation.Reference;
+
         public void Initialize(StateMachineBox box) =>
             _continuation.Initialize(box);
 

--- a/src/Kinetic/Linq/Observable.Count.cs
+++ b/src/Kinetic/Linq/Observable.Count.cs
@@ -22,11 +22,11 @@ public static partial class Observable
         public void Create<TContinuation>(in TContinuation continuation, ObserverStateMachine<TSource> source)
             where TContinuation : struct, IStateMachine<int>
         {
-            source.ContinueWith(new CountStateMachine<TContinuation, TSource>(continuation));
+            source.ContinueWith(new CountStateMachine<TSource, TContinuation>(continuation));
         }
     }
 
-    private struct CountStateMachine<TContinuation, TSource> : IStateMachine<TSource>
+    private struct CountStateMachine<TSource, TContinuation> : IStateMachine<TSource>
         where TContinuation : struct, IStateMachine<int>
     {
         private TContinuation _continuation;

--- a/src/Kinetic/Linq/Observable.DefaultIfEmpty.cs
+++ b/src/Kinetic/Linq/Observable.DefaultIfEmpty.cs
@@ -26,11 +26,11 @@ public static partial class Observable
         public void Create<TContinuation>(in TContinuation continuation, ObserverStateMachine<TSource> source)
             where TContinuation : struct, IStateMachine<TSource?>
         {
-            source.ContinueWith(new DefaultIfEmptyStateMachine<TContinuation, TSource>(continuation, _defaultValue));
+            source.ContinueWith(new DefaultIfEmptyStateMachine<TSource, TContinuation>(continuation, _defaultValue));
         }
     }
 
-    private struct DefaultIfEmptyStateMachine<TContinuation, TSource> : IStateMachine<TSource>
+    private struct DefaultIfEmptyStateMachine<TSource, TContinuation> : IStateMachine<TSource>
         where TContinuation : struct, IStateMachine<TSource?>
     {
         private TContinuation _continuation;

--- a/src/Kinetic/Linq/Observable.DefaultIfEmpty.cs
+++ b/src/Kinetic/Linq/Observable.DefaultIfEmpty.cs
@@ -47,6 +47,12 @@ public static partial class Observable
         public StateMachineBox Box =>
             _continuation.Box;
 
+        public StateMachine<TSource> Reference =>
+            StateMachine<TSource>.Create(ref this);
+
+        public StateMachine? Continuation =>
+            _continuation.Reference;
+
         public void Initialize(StateMachineBox box) =>
             _continuation.Initialize(box);
 

--- a/src/Kinetic/Linq/Observable.Distinct.cs
+++ b/src/Kinetic/Linq/Observable.Distinct.cs
@@ -24,11 +24,11 @@ public static partial class Observable
         public void Create<TContinuation>(in TContinuation continuation, ObserverStateMachine<TSource> source)
             where TContinuation : struct, IStateMachine<TSource>
         {
-            source.ContinueWith(new DistinctStateMachine<TContinuation, TSource>(continuation, _comparer));
+            source.ContinueWith(new DistinctStateMachine<TSource, TContinuation>(continuation, _comparer));
         }
     }
 
-    private struct DistinctStateMachine<TContinuation, TSource> : IStateMachine<TSource>
+    private struct DistinctStateMachine<TSource, TContinuation> : IStateMachine<TSource>
         where TContinuation : struct, IStateMachine<TSource>
     {
         private TContinuation _continuation;

--- a/src/Kinetic/Linq/Observable.Distinct.cs
+++ b/src/Kinetic/Linq/Observable.Distinct.cs
@@ -43,6 +43,12 @@ public static partial class Observable
         public StateMachineBox Box =>
             _continuation.Box;
 
+        public StateMachine<TSource> Reference =>
+            StateMachine<TSource>.Create(ref this);
+
+        public StateMachine? Continuation =>
+            _continuation.Reference;
+
         public void Initialize(StateMachineBox box) =>
             _continuation.Initialize(box);
 

--- a/src/Kinetic/Linq/Observable.Do.cs
+++ b/src/Kinetic/Linq/Observable.Do.cs
@@ -5,27 +5,27 @@ namespace Kinetic.Linq;
 
 public static partial class Observable
 {
-    public static ObserverBuilder<T> Do<T>(this IObservable<T> source, Action<T> onNext) =>
+    public static ObserverBuilder<TSource> Do<TSource>(this IObservable<TSource> source, Action<TSource> onNext) =>
         source.ToBuilder().Do(onNext);
 
-    public static ObserverBuilder<T> Do<T>(this IObservable<T> source, Action<T> onNext, Action<Exception> onError) =>
+    public static ObserverBuilder<TSource> Do<TSource>(this IObservable<TSource> source, Action<TSource> onNext, Action<Exception> onError) =>
         source.ToBuilder().Do(onNext, onError);
 
-    public static ObserverBuilder<T> Do<T>(this IObservable<T> source, Action<T> onNext, Action onCompleted) =>
+    public static ObserverBuilder<TSource> Do<TSource>(this IObservable<TSource> source, Action<TSource> onNext, Action onCompleted) =>
         source.ToBuilder().Do(onNext, onCompleted);
 
-    public static ObserverBuilder<T> Do<T>(this IObservable<T> source, Action<T> onNext, Action<Exception> onError, Action onCompleted) =>
+    public static ObserverBuilder<TSource> Do<TSource>(this IObservable<TSource> source, Action<TSource> onNext, Action<Exception> onError, Action onCompleted) =>
         source.ToBuilder().Do(onNext, onError, onCompleted);
 
-    public static ObserverBuilder<T> Do<T>(this ObserverBuilder<T> source, Action<T> onNext) =>
+    public static ObserverBuilder<TSource> Do<TSource>(this ObserverBuilder<TSource> source, Action<TSource> onNext) =>
         source.OnNext(onNext);
 
-    public static ObserverBuilder<T> Do<T>(this ObserverBuilder<T> source, Action<T> onNext, Action<Exception> onError) =>
+    public static ObserverBuilder<TSource> Do<TSource>(this ObserverBuilder<TSource> source, Action<TSource> onNext, Action<Exception> onError) =>
         source.OnError(onError).OnNext(onNext);
 
-    public static ObserverBuilder<T> Do<T>(this ObserverBuilder<T> source, Action<T> onNext, Action onCompleted) =>
+    public static ObserverBuilder<TSource> Do<TSource>(this ObserverBuilder<TSource> source, Action<TSource> onNext, Action onCompleted) =>
         source.OnNext(onNext).OnCompleted(onCompleted);
 
-    public static ObserverBuilder<T> Do<T>(this ObserverBuilder<T> source, Action<T> onNext, Action<Exception> onError, Action onCompleted) =>
+    public static ObserverBuilder<TSource> Do<TSource>(this ObserverBuilder<TSource> source, Action<TSource> onNext, Action<Exception> onError, Action onCompleted) =>
         source.OnError(onError).OnNext(onNext).OnCompleted(onCompleted);
 }

--- a/src/Kinetic/Linq/Observable.First.cs
+++ b/src/Kinetic/Linq/Observable.First.cs
@@ -41,6 +41,12 @@ public static partial class Observable
         public StateMachineBox Box =>
             _continuation.Box;
 
+        public StateMachine<TSource> Reference =>
+            StateMachine<TSource>.Create(ref this);
+
+        public StateMachine? Continuation =>
+            _continuation.Reference;
+
         public void Initialize(StateMachineBox box) =>
             _continuation.Initialize(box);
 

--- a/src/Kinetic/Linq/Observable.First.cs
+++ b/src/Kinetic/Linq/Observable.First.cs
@@ -1,5 +1,4 @@
 using System;
-using System.Collections.Generic;
 using Kinetic.Linq.StateMachines;
 
 namespace Kinetic.Linq;
@@ -23,11 +22,11 @@ public static partial class Observable
         public void Create<TContinuation>(in TContinuation continuation, ObserverStateMachine<TSource> source)
             where TContinuation : struct, IStateMachine<TSource>
         {
-            source.ContinueWith(new FirstStateMachine<TContinuation, TSource>(continuation));
+            source.ContinueWith(new FirstStateMachine<TSource, TContinuation>(continuation));
         }
     }
 
-    private struct FirstStateMachine<TContinuation, TSource> : IStateMachine<TSource>
+    private struct FirstStateMachine<TSource, TContinuation> : IStateMachine<TSource>
         where TContinuation : struct, IStateMachine<TSource>
     {
         private TContinuation _continuation;

--- a/src/Kinetic/Linq/Observable.FirstOrDefault.cs
+++ b/src/Kinetic/Linq/Observable.FirstOrDefault.cs
@@ -22,11 +22,11 @@ public static partial class Observable
         public void Create<TContinuation>(in TContinuation continuation, ObserverStateMachine<TSource> source)
             where TContinuation : struct, IStateMachine<TSource?>
         {
-            source.ContinueWith(new FirstOrDefaultStateMachine<TContinuation, TSource>(continuation));
+            source.ContinueWith(new FirstOrDefaultStateMachine<TSource, TContinuation>(continuation));
         }
     }
 
-    private struct FirstOrDefaultStateMachine<TContinuation, TSource> : IStateMachine<TSource>
+    private struct FirstOrDefaultStateMachine<TSource, TContinuation> : IStateMachine<TSource>
         where TContinuation : struct, IStateMachine<TSource?>
     {
         private TContinuation _continuation;

--- a/src/Kinetic/Linq/Observable.FirstOrDefault.cs
+++ b/src/Kinetic/Linq/Observable.FirstOrDefault.cs
@@ -37,6 +37,12 @@ public static partial class Observable
         public StateMachineBox Box =>
             _continuation.Box;
 
+        public StateMachine<TSource> Reference =>
+            StateMachine<TSource>.Create(ref this);
+
+        public StateMachine? Continuation =>
+            _continuation.Reference;
+
         public void Initialize(StateMachineBox box) =>
             _continuation.Initialize(box);
 

--- a/src/Kinetic/Linq/Observable.Last.cs
+++ b/src/Kinetic/Linq/Observable.Last.cs
@@ -23,11 +23,11 @@ public static partial class Observable
         public void Create<TContinuation>(in TContinuation continuation, ObserverStateMachine<TSource> source)
             where TContinuation : struct, IStateMachine<TSource>
         {
-            source.ContinueWith(new LastStateMachine<TContinuation, TSource>(continuation));
+            source.ContinueWith(new LastStateMachine<TSource, TContinuation>(continuation));
         }
     }
 
-    private struct LastStateMachine<TContinuation, TSource> : IStateMachine<TSource>
+    private struct LastStateMachine<TSource, TContinuation> : IStateMachine<TSource>
         where TContinuation : struct, IStateMachine<TSource>
     {
         private TContinuation _continuation;

--- a/src/Kinetic/Linq/Observable.Last.cs
+++ b/src/Kinetic/Linq/Observable.Last.cs
@@ -42,6 +42,12 @@ public static partial class Observable
         public StateMachineBox Box =>
             _continuation.Box;
 
+        public StateMachine<TSource> Reference =>
+            StateMachine<TSource>.Create(ref this);
+
+        public StateMachine? Continuation =>
+            _continuation.Reference;
+
         public void Initialize(StateMachineBox box) =>
             _continuation.Initialize(box);
 

--- a/src/Kinetic/Linq/Observable.LastOrDefault.cs
+++ b/src/Kinetic/Linq/Observable.LastOrDefault.cs
@@ -41,6 +41,12 @@ public static partial class Observable
         public StateMachineBox Box =>
             _continuation.Box;
 
+        public StateMachine<TSource> Reference =>
+            StateMachine<TSource>.Create(ref this);
+
+        public StateMachine? Continuation =>
+            _continuation.Reference;
+
         public void Initialize(StateMachineBox box) =>
             _continuation.Initialize(box);
 

--- a/src/Kinetic/Linq/Observable.LastOrDefault.cs
+++ b/src/Kinetic/Linq/Observable.LastOrDefault.cs
@@ -22,11 +22,11 @@ public static partial class Observable
         public void Create<TContinuation>(in TContinuation continuation, ObserverStateMachine<TSource> source)
             where TContinuation : struct, IStateMachine<TSource?>
         {
-            source.ContinueWith(new LastOrDefaultStateMachine<TContinuation, TSource>(continuation));
+            source.ContinueWith(new LastOrDefaultStateMachine<TSource, TContinuation>(continuation));
         }
     }
 
-    private struct LastOrDefaultStateMachine<TContinuation, TSource> : IStateMachine<TSource>
+    private struct LastOrDefaultStateMachine<TSource, TContinuation> : IStateMachine<TSource>
         where TContinuation : struct, IStateMachine<TSource?>
     {
         private TContinuation _continuation;

--- a/src/Kinetic/Linq/Observable.Max.cs
+++ b/src/Kinetic/Linq/Observable.Max.cs
@@ -22,11 +22,11 @@ public static partial class Observable
         public void Create<TContinuation>(in TContinuation continuation, ObserverStateMachine<TSource> source)
             where TContinuation : struct, IStateMachine<TSource>
         {
-            source.ContinueWith(new MaxStateMachine<TContinuation, TSource>(continuation, _comparer));
+            source.ContinueWith(new MaxStateMachine<TSource, TContinuation>(continuation, _comparer));
         }
     }
 
-    private struct MaxStateMachine<TContinuation, TSource> : IStateMachine<TSource>
+    private struct MaxStateMachine<TSource, TContinuation> : IStateMachine<TSource>
         where TContinuation : struct, IStateMachine<TSource>
     {
         private TContinuation _continuation;

--- a/src/Kinetic/Linq/Observable.Max.cs
+++ b/src/Kinetic/Linq/Observable.Max.cs
@@ -45,6 +45,12 @@ public static partial class Observable
         public StateMachineBox Box =>
             _continuation.Box;
 
+        public StateMachine<TSource> Reference =>
+            StateMachine<TSource>.Create(ref this);
+
+        public StateMachine? Continuation =>
+            _continuation.Reference;
+
         public void Initialize(StateMachineBox box) =>
             _continuation.Initialize(box);
 

--- a/src/Kinetic/Linq/Observable.Min.cs
+++ b/src/Kinetic/Linq/Observable.Min.cs
@@ -45,6 +45,12 @@ public static partial class Observable
         public StateMachineBox Box =>
             _continuation.Box;
 
+        public StateMachine<TSource> Reference =>
+            StateMachine<TSource>.Create(ref this);
+
+        public StateMachine? Continuation =>
+            _continuation.Reference;
+
         public void Initialize(StateMachineBox box) =>
             _continuation.Initialize(box);
 

--- a/src/Kinetic/Linq/Observable.Min.cs
+++ b/src/Kinetic/Linq/Observable.Min.cs
@@ -22,11 +22,11 @@ public static partial class Observable
         public void Create<TContinuation>(in TContinuation continuation, ObserverStateMachine<TSource> source)
             where TContinuation : struct, IStateMachine<TSource>
         {
-            source.ContinueWith(new MinStateMachine<TContinuation, TSource>(continuation, _comparer));
+            source.ContinueWith(new MinStateMachine<TSource, TContinuation>(continuation, _comparer));
         }
     }
 
-    private struct MinStateMachine<TContinuation, TSource> : IStateMachine<TSource>
+    private struct MinStateMachine<TSource, TContinuation> : IStateMachine<TSource>
         where TContinuation : struct, IStateMachine<TSource>
     {
         private TContinuation _continuation;

--- a/src/Kinetic/Linq/Observable.OnCompleted.cs
+++ b/src/Kinetic/Linq/Observable.OnCompleted.cs
@@ -40,6 +40,12 @@ public static partial class Observable
         public StateMachineBox Box =>
             _continuation.Box;
 
+        public StateMachine<TSource> Reference =>
+            StateMachine<TSource>.Create(ref this);
+
+        public StateMachine? Continuation =>
+            _continuation.Reference;
+
         public void Initialize(StateMachineBox box) =>
             _continuation.Initialize(box);
 

--- a/src/Kinetic/Linq/Observable.OnCompleted.cs
+++ b/src/Kinetic/Linq/Observable.OnCompleted.cs
@@ -5,28 +5,28 @@ namespace Kinetic.Linq;
 
 public static partial class Observable
 {
-    public static ObserverBuilder<T> OnCompleted<T>(this IObservable<T> source, Action onCompleted) =>
+    public static ObserverBuilder<TSource> OnCompleted<TSource>(this IObservable<TSource> source, Action onCompleted) =>
         source.ToBuilder().OnCompleted(onCompleted);
 
-    public static ObserverBuilder<T> OnCompleted<T>(this ObserverBuilder<T> source, Action onCompleted) =>
-        source.ContinueWith<OnCompletedStateMachineFactory<T>, T>(new(onCompleted));
+    public static ObserverBuilder<TSource> OnCompleted<TSource>(this ObserverBuilder<TSource> source, Action onCompleted) =>
+        source.ContinueWith<OnCompletedStateMachineFactory<TSource>, TSource>(new(onCompleted));
 
-    private readonly struct OnCompletedStateMachineFactory<T> : IStateMachineFactory<T, T>
+    private readonly struct OnCompletedStateMachineFactory<TSource> : IStateMachineFactory<TSource, TSource>
     {
         private readonly Action _onCompleted;
 
         public OnCompletedStateMachineFactory(Action onCompleted) =>
             _onCompleted = onCompleted;
 
-        public void Create<TContinuation>(in TContinuation continuation, ObserverStateMachine<T> source)
-            where TContinuation : struct, IStateMachine<T>
+        public void Create<TContinuation>(in TContinuation continuation, ObserverStateMachine<TSource> source)
+            where TContinuation : struct, IStateMachine<TSource>
         {
-            source.ContinueWith(new OnCompletedStateMachine<TContinuation, T>(continuation, _onCompleted));
+            source.ContinueWith(new OnCompletedStateMachine<TSource, TContinuation>(continuation, _onCompleted));
         }
     }
 
-    private struct OnCompletedStateMachine<TContinuation, T> : IStateMachine<T>
-        where TContinuation : struct, IStateMachine<T>
+    private struct OnCompletedStateMachine<TSource, TContinuation> : IStateMachine<TSource>
+        where TContinuation : struct, IStateMachine<TSource>
     {
         private TContinuation _continuation;
         private readonly Action _onCompleted;
@@ -46,7 +46,7 @@ public static partial class Observable
         public void Dispose() =>
             _continuation.Dispose();
 
-        public void OnNext(T value) =>
+        public void OnNext(TSource value) =>
             _continuation.OnNext(value);
 
         public void OnError(Exception error) =>

--- a/src/Kinetic/Linq/Observable.OnCompletedAsync.cs
+++ b/src/Kinetic/Linq/Observable.OnCompletedAsync.cs
@@ -68,6 +68,12 @@ public static partial class Observable
         public StateMachineBox Box =>
             _continuation.Box;
 
+        public StateMachine<TSource> Reference =>
+            StateMachine<TSource>.Create(ref this);
+
+        public StateMachine? Continuation =>
+            _continuation.Reference;
+
         public void Initialize(StateMachineBox box) =>
             _continuation.Initialize(box);
 

--- a/src/Kinetic/Linq/Observable.OnError.cs
+++ b/src/Kinetic/Linq/Observable.OnError.cs
@@ -40,6 +40,12 @@ public static partial class Observable
         public StateMachineBox Box =>
             _continuation.Box;
 
+        public StateMachine<TSource> Reference =>
+            StateMachine<TSource>.Create(ref this);
+
+        public StateMachine? Continuation =>
+            _continuation.Reference;
+
         public void Initialize(StateMachineBox box) =>
             _continuation.Initialize(box);
 

--- a/src/Kinetic/Linq/Observable.OnErrorAsync.cs
+++ b/src/Kinetic/Linq/Observable.OnErrorAsync.cs
@@ -67,6 +67,12 @@ public static partial class Observable
         public StateMachineBox Box =>
             _continuation.Box;
 
+        public StateMachine<TSource> Reference =>
+            StateMachine<TSource>.Create(ref this);
+
+        public StateMachine? Continuation =>
+            _continuation.Reference;
+
         public void Initialize(StateMachineBox box) =>
             _continuation.Initialize(box);
 

--- a/src/Kinetic/Linq/Observable.OnNext.cs
+++ b/src/Kinetic/Linq/Observable.OnNext.cs
@@ -40,6 +40,12 @@ public static partial class Observable
         public StateMachineBox Box =>
             _continuation.Box;
 
+        public StateMachine<TSource> Reference =>
+            StateMachine<TSource>.Create(ref this);
+
+        public StateMachine? Continuation =>
+            _continuation.Reference;
+
         public void Initialize(StateMachineBox box) =>
             _continuation.Initialize(box);
 

--- a/src/Kinetic/Linq/Observable.OnNext.cs
+++ b/src/Kinetic/Linq/Observable.OnNext.cs
@@ -5,33 +5,33 @@ namespace Kinetic.Linq;
 
 public static partial class Observable
 {
-    public static ObserverBuilder<T> OnNext<T>(this IObservable<T> source, Action<T> onNext) =>
+    public static ObserverBuilder<TSource> OnNext<TSource>(this IObservable<TSource> source, Action<TSource> onNext) =>
         source.ToBuilder().OnNext(onNext);
 
-    public static ObserverBuilder<T> OnNext<T>(this ObserverBuilder<T> source, Action<T> onNext) =>
-        source.ContinueWith<OnNextStateMachineFactory<T>, T>(new(onNext));
+    public static ObserverBuilder<TSource> OnNext<TSource>(this ObserverBuilder<TSource> source, Action<TSource> onNext) =>
+        source.ContinueWith<OnNextStateMachineFactory<TSource>, TSource>(new(onNext));
 
-    private readonly struct OnNextStateMachineFactory<T> : IStateMachineFactory<T, T>
+    private readonly struct OnNextStateMachineFactory<TSource> : IStateMachineFactory<TSource, TSource>
     {
-        private readonly Action<T> _onNext;
+        private readonly Action<TSource> _onNext;
 
-        public OnNextStateMachineFactory(Action<T> onNext) =>
+        public OnNextStateMachineFactory(Action<TSource> onNext) =>
             _onNext = onNext;
 
-        public void Create<TContinuation>(in TContinuation continuation, ObserverStateMachine<T> source)
-            where TContinuation : struct, IStateMachine<T>
+        public void Create<TContinuation>(in TContinuation continuation, ObserverStateMachine<TSource> source)
+            where TContinuation : struct, IStateMachine<TSource>
         {
-            source.ContinueWith(new OnNextStateMachine<TContinuation, T>(continuation, _onNext));
+            source.ContinueWith(new OnNextStateMachine<TSource, TContinuation>(continuation, _onNext));
         }
     }
 
-    private struct OnNextStateMachine<TContinuation, T> : IStateMachine<T>
-        where TContinuation : struct, IStateMachine<T>
+    private struct OnNextStateMachine<TSource, TContinuation> : IStateMachine<TSource>
+        where TContinuation : struct, IStateMachine<TSource>
     {
         private TContinuation _continuation;
-        private readonly Action<T> _onNext;
+        private readonly Action<TSource> _onNext;
 
-        public OnNextStateMachine(in TContinuation continuation, Action<T> onNext)
+        public OnNextStateMachine(in TContinuation continuation, Action<TSource> onNext)
         {
             _continuation = continuation;
             _onNext = onNext;
@@ -46,7 +46,7 @@ public static partial class Observable
         public void Dispose() =>
             _continuation.Dispose();
 
-        public void OnNext(T value)
+        public void OnNext(TSource value)
         {
             try
             {

--- a/src/Kinetic/Linq/Observable.OnNextAsync.cs
+++ b/src/Kinetic/Linq/Observable.OnNextAsync.cs
@@ -66,6 +66,12 @@ public static partial class Observable
         public StateMachineBox Box =>
             _continuation.Box;
 
+        public StateMachine<TSource> Reference =>
+            StateMachine<TSource>.Create(ref this);
+
+        public StateMachine? Continuation =>
+            _continuation.Reference;
+
         public void Initialize(StateMachineBox box) =>
             _continuation.Initialize(box);
 

--- a/src/Kinetic/Linq/Observable.Select.cs
+++ b/src/Kinetic/Linq/Observable.Select.cs
@@ -20,11 +20,11 @@ public static partial class Observable
         public void Create<TContinuation>(in TContinuation continuation, ObserverStateMachine<TSource> source)
             where TContinuation : struct, IStateMachine<TResult>
         {
-            source.ContinueWith(new SelectStateMachine<TContinuation, TSource, TResult>(continuation, _selector));
+            source.ContinueWith(new SelectStateMachine<TSource, TResult, TContinuation>(continuation, _selector));
         }
     }
 
-    private struct SelectStateMachine<TContinuation, TSource, TResult> : IStateMachine<TSource>
+    private struct SelectStateMachine<TSource, TResult, TContinuation> : IStateMachine<TSource>
         where TContinuation : struct, IStateMachine<TResult>
     {
         private TContinuation _continuation;

--- a/src/Kinetic/Linq/Observable.Select.cs
+++ b/src/Kinetic/Linq/Observable.Select.cs
@@ -39,6 +39,12 @@ public static partial class Observable
         public StateMachineBox Box =>
             _continuation.Box;
 
+        public StateMachine<TSource> Reference =>
+            StateMachine<TSource>.Create(ref this);
+
+        public StateMachine? Continuation =>
+            _continuation.Reference;
+
         public void Initialize(StateMachineBox box) =>
             _continuation.Initialize(box);
 

--- a/src/Kinetic/Linq/Observable.SelectAsync.cs
+++ b/src/Kinetic/Linq/Observable.SelectAsync.cs
@@ -35,9 +35,9 @@ public static partial class Observable
             {
                 source.ContinueWith(
                     new SelectAsyncStateMachine<
-                        TContinuation,
                         TSource,
                         TResult,
+                        TContinuation,
                         AwaiterForTask<TResult>,
                         AwaiterFactoryForTask<TSource, TResult>>
                         (continuation, new(taskSelector)));
@@ -49,9 +49,9 @@ public static partial class Observable
             {
                 source.ContinueWith(
                     new SelectAsyncStateMachine<
-                        TContinuation,
                         TSource,
                         TResult,
+                        TContinuation,
                         AwaiterForValueTask<TResult>,
                         AwaiterFactoryForValueTask<TSource, TResult>>
                         (continuation, new(valueTaskSelector)));
@@ -63,7 +63,7 @@ public static partial class Observable
         }
     }
 
-    private struct SelectAsyncStateMachine<TContinuation, TSource, TResult, TAwaiter, TAwaiterFactory> : IStateMachine<TSource>
+    private struct SelectAsyncStateMachine<TSource, TResult, TContinuation, TAwaiter, TAwaiterFactory> : IStateMachine<TSource>
         where TContinuation : struct, IStateMachine<TResult>
         where TAwaiter : struct, IAwaiter<TResult>
         where TAwaiterFactory : struct, IAwaiterFactory<TAwaiter, TSource, TResult>

--- a/src/Kinetic/Linq/Observable.SelectAsync.cs
+++ b/src/Kinetic/Linq/Observable.SelectAsync.cs
@@ -80,6 +80,12 @@ public static partial class Observable
         public StateMachineBox Box =>
             _continuation.Box;
 
+        public StateMachine<TSource> Reference =>
+            StateMachine<TSource>.Create(ref this);
+
+        public StateMachine? Continuation =>
+            _continuation.Reference;
+
         public void Initialize(StateMachineBox box) =>
             _continuation.Initialize(box);
 

--- a/src/Kinetic/Linq/Observable.Single.cs
+++ b/src/Kinetic/Linq/Observable.Single.cs
@@ -23,11 +23,11 @@ public static partial class Observable
         public void Create<TContinuation>(in TContinuation continuation, ObserverStateMachine<TSource> source)
             where TContinuation : struct, IStateMachine<TSource>
         {
-            source.ContinueWith(new SingleStateMachine<TContinuation, TSource>(continuation));
+            source.ContinueWith(new SingleStateMachine<TSource, TContinuation>(continuation));
         }
     }
 
-    private struct SingleStateMachine<TContinuation, TSource> : IStateMachine<TSource>
+    private struct SingleStateMachine<TSource, TContinuation> : IStateMachine<TSource>
         where TContinuation : struct, IStateMachine<TSource>
     {
         private TContinuation _continuation;

--- a/src/Kinetic/Linq/Observable.Single.cs
+++ b/src/Kinetic/Linq/Observable.Single.cs
@@ -42,6 +42,12 @@ public static partial class Observable
         public StateMachineBox Box =>
             _continuation.Box;
 
+        public StateMachine<TSource> Reference =>
+            StateMachine<TSource>.Create(ref this);
+
+        public StateMachine? Continuation =>
+            _continuation.Reference;
+
         public void Initialize(StateMachineBox box) =>
             _continuation.Initialize(box);
 

--- a/src/Kinetic/Linq/Observable.SingleOrDefault.cs
+++ b/src/Kinetic/Linq/Observable.SingleOrDefault.cs
@@ -23,11 +23,11 @@ public static partial class Observable
         public void Create<TContinuation>(in TContinuation continuation, ObserverStateMachine<TSource> source)
             where TContinuation : struct, IStateMachine<TSource>
         {
-            source.ContinueWith(new SingleOrDefaultStateMachine<TContinuation, TSource>(continuation));
+            source.ContinueWith(new SingleOrDefaultStateMachine<TSource, TContinuation>(continuation));
         }
     }
 
-    private struct SingleOrDefaultStateMachine<TContinuation, TSource> : IStateMachine<TSource>
+    private struct SingleOrDefaultStateMachine<TSource, TContinuation> : IStateMachine<TSource>
         where TContinuation : struct, IStateMachine<TSource>
     {
         private TContinuation _continuation;

--- a/src/Kinetic/Linq/Observable.SingleOrDefault.cs
+++ b/src/Kinetic/Linq/Observable.SingleOrDefault.cs
@@ -42,6 +42,12 @@ public static partial class Observable
         public StateMachineBox Box =>
             _continuation.Box;
 
+        public StateMachine<TSource> Reference =>
+            StateMachine<TSource>.Create(ref this);
+
+        public StateMachine? Continuation =>
+            _continuation.Reference;
+
         public void Initialize(StateMachineBox box) =>
             _continuation.Initialize(box);
 

--- a/src/Kinetic/Linq/Observable.Skip.cs
+++ b/src/Kinetic/Linq/Observable.Skip.cs
@@ -23,11 +23,11 @@ public static partial class Observable
         public void Create<TContinuation>(in TContinuation continuation, ObserverStateMachine<TSource> source)
             where TContinuation : struct, IStateMachine<TSource>
         {
-            source.ContinueWith(new SkipStateMachine<TContinuation, TSource>(continuation, (uint) _count));
+            source.ContinueWith(new SkipStateMachine<TSource, TContinuation>(continuation, (uint) _count));
         }
     }
 
-    private struct SkipStateMachine<TContinuation, TSource> : IStateMachine<TSource>
+    private struct SkipStateMachine<TSource, TContinuation> : IStateMachine<TSource>
         where TContinuation : struct, IStateMachine<TSource>
     {
         private TContinuation _continuation;

--- a/src/Kinetic/Linq/Observable.Skip.cs
+++ b/src/Kinetic/Linq/Observable.Skip.cs
@@ -42,6 +42,12 @@ public static partial class Observable
         public StateMachineBox Box =>
             _continuation.Box;
 
+        public StateMachine<TSource> Reference =>
+            StateMachine<TSource>.Create(ref this);
+
+        public StateMachine? Continuation =>
+            _continuation.Reference;
+
         public void Initialize(StateMachineBox box) =>
             _continuation.Initialize(box);
 

--- a/src/Kinetic/Linq/Observable.SkipWhile.cs
+++ b/src/Kinetic/Linq/Observable.SkipWhile.cs
@@ -23,11 +23,11 @@ public static partial class Observable
         public void Create<TContinuation>(in TContinuation continuation, ObserverStateMachine<TSource> source)
             where TContinuation : struct, IStateMachine<TSource>
         {
-            source.ContinueWith(new SkipWhileStateMachine<TContinuation, TSource>(continuation, _predicate));
+            source.ContinueWith(new SkipWhileStateMachine<TSource, TContinuation>(continuation, _predicate));
         }
     }
 
-    private struct SkipWhileStateMachine<TContinuation, TSource> : IStateMachine<TSource>
+    private struct SkipWhileStateMachine<TSource, TContinuation> : IStateMachine<TSource>
         where TContinuation : struct, IStateMachine<TSource>
     {
         private TContinuation _continuation;

--- a/src/Kinetic/Linq/Observable.SkipWhile.cs
+++ b/src/Kinetic/Linq/Observable.SkipWhile.cs
@@ -42,6 +42,12 @@ public static partial class Observable
         public StateMachineBox Box =>
             _continuation.Box;
 
+        public StateMachine<TSource> Reference =>
+            StateMachine<TSource>.Create(ref this);
+
+        public StateMachine? Continuation =>
+            _continuation.Reference;
+
         public void Initialize(StateMachineBox box) =>
             _continuation.Initialize(box);
 

--- a/src/Kinetic/Linq/Observable.Subscribe.cs
+++ b/src/Kinetic/Linq/Observable.Subscribe.cs
@@ -6,40 +6,40 @@ namespace Kinetic.Linq;
 
 public static partial class Observable
 {
-    public static IDisposable Subscribe<T>(this IObservable<T> source) =>
+    public static IDisposable Subscribe<TSource>(this IObservable<TSource> source) =>
         source.ToBuilder().Subscribe();
 
-    public static IDisposable Subscribe<T>(this IObservable<T> source, Action<T> onNext) =>
+    public static IDisposable Subscribe<TSource>(this IObservable<TSource> source, Action<TSource> onNext) =>
         source.ToBuilder().Subscribe(onNext);
 
-    public static IDisposable Subscribe<T>(this IObservable<T> source, Action<T> onNext, Action<Exception> onError) =>
+    public static IDisposable Subscribe<TSource>(this IObservable<TSource> source, Action<TSource> onNext, Action<Exception> onError) =>
         source.ToBuilder().Subscribe(onNext, onError);
 
-    public static IDisposable Subscribe<T>(this IObservable<T> source, Action<T> onNext, Action onCompleted) =>
+    public static IDisposable Subscribe<TSource>(this IObservable<TSource> source, Action<TSource> onNext, Action onCompleted) =>
         source.ToBuilder().Subscribe(onNext, onCompleted);
 
-    public static IDisposable Subscribe<T>(this IObservable<T> source, Action<T> onNext, Action<Exception> onError, Action onCompleted) =>
+    public static IDisposable Subscribe<TSource>(this IObservable<TSource> source, Action<TSource> onNext, Action<Exception> onError, Action onCompleted) =>
         source.ToBuilder().Subscribe(onNext, onError, onCompleted);
 
-    public static IDisposable Subscribe<T>(this ObserverBuilder<T> source) =>
-        source.Build<SubscribeStateMachine<T>, SubscribeBoxFactory, IDisposable>(
+    public static IDisposable Subscribe<TSource>(this ObserverBuilder<TSource> source) =>
+        source.Build<SubscribeStateMachine<TSource>, SubscribeBoxFactory, IDisposable>(
             continuation: new(),
             factory: new());
 
-    public static IDisposable Subscribe<T>(this ObserverBuilder<T> source, Action<T> onNext) =>
+    public static IDisposable Subscribe<TSource>(this ObserverBuilder<TSource> source, Action<TSource> onNext) =>
         source.Do(onNext).Subscribe();
 
-    public static IDisposable Subscribe<T>(this ObserverBuilder<T> source, Action<T> onNext, Action<Exception> onError) =>
+    public static IDisposable Subscribe<TSource>(this ObserverBuilder<TSource> source, Action<TSource> onNext, Action<Exception> onError) =>
         source.Do(onNext, onError).Subscribe();
 
-    public static IDisposable Subscribe<T>(this ObserverBuilder<T> source, Action<T> onNext, Action onCompleted) =>
+    public static IDisposable Subscribe<TSource>(this ObserverBuilder<TSource> source, Action<TSource> onNext, Action onCompleted) =>
         source.Do(onNext, onCompleted).Subscribe();
 
-    public static IDisposable Subscribe<T>(this ObserverBuilder<T> source, Action<T> onNext, Action<Exception> onError, Action onCompleted) =>
+    public static IDisposable Subscribe<TSource>(this ObserverBuilder<TSource> source, Action<TSource> onNext, Action<Exception> onError, Action onCompleted) =>
         source.Do(onNext, onError, onCompleted).Subscribe();
 
-    private sealed class SubscribeBox<T, TStateMachine> : StateMachineBox<T, TStateMachine>, IDisposable
-        where TStateMachine : struct, IStateMachine<T>
+    private sealed class SubscribeBox<TSource, TStateMachine> : StateMachineBox<TSource, TStateMachine>, IDisposable
+        where TStateMachine : struct, IStateMachine<TSource>
     {
         public SubscribeBox(in TStateMachine stateMachine) :
             base(stateMachine) => StateMachine.Initialize(this);
@@ -55,12 +55,18 @@ public static partial class Observable
             new SubscribeBox<T, TStateMachine>(stateMachine);
     }
 
-    private struct SubscribeStateMachine<T> : IStateMachine<T>
+    private struct SubscribeStateMachine<TSource> : IStateMachine<TSource>
     {
         private StateMachineBox? _box;
 
         public StateMachineBox Box =>
             _box ?? throw new InvalidOperationException();
+
+        public StateMachine<TSource> Reference =>
+            StateMachine<TSource>.Create(ref this);
+
+        public StateMachine? Continuation =>
+            null;
 
         public void Initialize(StateMachineBox box) =>
             _box = box;
@@ -73,6 +79,6 @@ public static partial class Observable
         public void OnError(Exception error) =>
             ExceptionDispatchInfo.Capture(error).Throw();
 
-        public void OnNext(T value) { }
+        public void OnNext(TSource value) { }
     }
 }

--- a/src/Kinetic/Linq/Observable.Take.cs
+++ b/src/Kinetic/Linq/Observable.Take.cs
@@ -23,11 +23,11 @@ public static partial class Observable
         public void Create<TContinuation>(in TContinuation continuation, ObserverStateMachine<TSource> source)
             where TContinuation : struct, IStateMachine<TSource>
         {
-            source.ContinueWith(new TakeStateMachine<TContinuation, TSource>(continuation, (uint) _count));
+            source.ContinueWith(new TakeStateMachine<TSource, TContinuation>(continuation, (uint) _count));
         }
     }
 
-    private struct TakeStateMachine<TContinuation, TSource> : IStateMachine<TSource>
+    private struct TakeStateMachine<TSource, TContinuation> : IStateMachine<TSource>
         where TContinuation : struct, IStateMachine<TSource>
     {
         private TContinuation _continuation;

--- a/src/Kinetic/Linq/Observable.Take.cs
+++ b/src/Kinetic/Linq/Observable.Take.cs
@@ -42,6 +42,12 @@ public static partial class Observable
         public StateMachineBox Box =>
             _continuation.Box;
 
+        public StateMachine<TSource> Reference =>
+            StateMachine<TSource>.Create(ref this);
+
+        public StateMachine? Continuation =>
+            _continuation.Reference;
+
         public void Initialize(StateMachineBox box) =>
             _continuation.Initialize(box);
 

--- a/src/Kinetic/Linq/Observable.TakeWhile.cs
+++ b/src/Kinetic/Linq/Observable.TakeWhile.cs
@@ -23,11 +23,11 @@ public static partial class Observable
         public void Create<TContinuation>(in TContinuation continuation, ObserverStateMachine<TSource> source)
             where TContinuation : struct, IStateMachine<TSource>
         {
-            source.ContinueWith(new TakeWhileStateMachine<TContinuation, TSource>(continuation, _predicate));
+            source.ContinueWith(new TakeWhileStateMachine<TSource, TContinuation>(continuation, _predicate));
         }
     }
 
-    private struct TakeWhileStateMachine<TContinuation, TSource> : IStateMachine<TSource>
+    private struct TakeWhileStateMachine<TSource, TContinuation> : IStateMachine<TSource>
         where TContinuation : struct, IStateMachine<TSource>
     {
         private TContinuation _continuation;

--- a/src/Kinetic/Linq/Observable.TakeWhile.cs
+++ b/src/Kinetic/Linq/Observable.TakeWhile.cs
@@ -42,6 +42,12 @@ public static partial class Observable
         public StateMachineBox Box =>
             _continuation.Box;
 
+        public StateMachine<TSource> Reference =>
+            StateMachine<TSource>.Create(ref this);
+
+        public StateMachine? Continuation =>
+            _continuation.Reference;
+
         public void Initialize(StateMachineBox box) =>
             _continuation.Initialize(box);
 

--- a/src/Kinetic/Linq/Observable.Then.cs
+++ b/src/Kinetic/Linq/Observable.Then.cs
@@ -40,6 +40,12 @@ public static partial class Observable
         public StateMachineBox Box =>
             _continuation.Box;
 
+        public StateMachine<TSource> Reference =>
+            StateMachine<TSource>.Create(ref this);
+
+        public StateMachine? Continuation =>
+            _continuation.Reference;
+
         public void Initialize(StateMachineBox box) =>
             _continuation.Initialize(box);
 

--- a/src/Kinetic/Linq/Observable.Then.cs
+++ b/src/Kinetic/Linq/Observable.Then.cs
@@ -20,11 +20,11 @@ public static partial class Observable
         public void Create<TContinuation>(in TContinuation continuation, ObserverStateMachine<TSource> source)
             where TContinuation : struct, IStateMachine<TResult>
         {
-            source.ContinueWith(new ThenStateMachine<TContinuation, TSource, TResult>(continuation, _selector));
+            source.ContinueWith(new ThenStateMachine<TSource, TResult, TContinuation>(continuation, _selector));
         }
     }
 
-    private struct ThenStateMachine<TContinuation, TSource, TResult> : IStateMachine<TSource>
+    private struct ThenStateMachine<TSource, TResult, TContinuation> : IStateMachine<TSource>
         where TContinuation : struct, IStateMachine<TResult>
     {
         private TContinuation _continuation;

--- a/src/Kinetic/Linq/Observable.Throttle.cs
+++ b/src/Kinetic/Linq/Observable.Throttle.cs
@@ -28,11 +28,11 @@ public static partial class Observable
         public void Create<TContinuation>(in TContinuation continuation, ObserverStateMachine<TSource> source)
             where TContinuation : struct, IStateMachine<TSource>
         {
-            source.ContinueWith(new ThrottleStateMachine<TContinuation, TSource>(continuation, _delay, _continueOnCapturedContext));
+            source.ContinueWith(new ThrottleStateMachine<TSource, TContinuation>(continuation, _delay, _continueOnCapturedContext));
         }
     }
 
-    private struct ThrottleStateMachine<TContinuation, TSource> : IStateMachine<TSource>
+    private struct ThrottleStateMachine<TSource, TContinuation> : IStateMachine<TSource>
         where TContinuation : struct, IStateMachine<TSource>
     {
         private TContinuation _continuation;

--- a/src/Kinetic/Linq/Observable.Throttle.cs
+++ b/src/Kinetic/Linq/Observable.Throttle.cs
@@ -47,6 +47,12 @@ public static partial class Observable
         public StateMachineBox Box =>
             _continuation.Box;
 
+        public StateMachine<TSource> Reference =>
+            StateMachine<TSource>.Create(ref this);
+
+        public StateMachine? Continuation =>
+            _continuation.Reference;
+
         public void Initialize(StateMachineBox box) =>
             _continuation.Initialize(box);
 

--- a/src/Kinetic/Linq/Observable.ToArray.cs
+++ b/src/Kinetic/Linq/Observable.ToArray.cs
@@ -5,32 +5,32 @@ namespace Kinetic.Linq;
 
 public static partial class Observable
 {
-    public static ObserverBuilder<TResult[]> ToArray<TResult>(this ObserverBuilder<TResult> source) =>
-        source.ContinueWith<ToArrayStateMachineFactory<TResult>, TResult[]>(default);
+    public static ObserverBuilder<TSource[]> ToArray<TSource>(this ObserverBuilder<TSource> source) =>
+        source.ContinueWith<ToArrayStateMachineFactory<TSource>, TSource[]>(default);
 
-    public static ObserverBuilder<TResult[]> ToArray<TResult>(this IObservable<TResult> source) =>
+    public static ObserverBuilder<TSource[]> ToArray<TSource>(this IObservable<TSource> source) =>
         source.ToBuilder().ToArray();
 
-    private readonly struct ToArrayStateMachineFactory<TResult> : IStateMachineFactory<TResult, TResult[]>
+    private readonly struct ToArrayStateMachineFactory<TSource> : IStateMachineFactory<TSource, TSource[]>
     {
-        public void Create<TContinuation>(in TContinuation continuation, ObserverStateMachine<TResult> source)
-            where TContinuation : struct, IStateMachine<TResult[]>
+        public void Create<TContinuation>(in TContinuation continuation, ObserverStateMachine<TSource> source)
+            where TContinuation : struct, IStateMachine<TSource[]>
         {
-            source.ContinueWith(new ToArrayStateMachine<TContinuation, TResult>(continuation));
+            source.ContinueWith(new ToArrayStateMachine<TSource, TContinuation>(continuation));
         }
     }
 
-    private struct ToArrayStateMachine<TContinuation, TResult> : IStateMachine<TResult>
-        where TContinuation : struct, IStateMachine<TResult[]>
+    private struct ToArrayStateMachine<TSource, TContinuation> : IStateMachine<TSource>
+        where TContinuation : struct, IStateMachine<TSource[]>
     {
         private TContinuation _continuation;
-        private TResult[] _result;
+        private TSource[] _result;
         private int _length;
 
         public ToArrayStateMachine(in TContinuation continuation)
         {
             _continuation = continuation;
-            _result = Array.Empty<TResult>();
+            _result = Array.Empty<TSource>();
         }
 
         public StateMachineBox Box =>
@@ -45,7 +45,7 @@ public static partial class Observable
         private void IncreareResultLength()
         {
             var length = _length == 0 ? 4 : _length * 2;
-            var result = new TResult[length];
+            var result = new TSource[length];
 
             if (_length != 0)
             {
@@ -55,7 +55,7 @@ public static partial class Observable
             _result = result;
         }
 
-        public void OnNext(TResult value)
+        public void OnNext(TSource value)
         {
             if (_result.Length == _length)
             {
@@ -74,7 +74,7 @@ public static partial class Observable
             var result = _result;
             if (result.Length != _length)
             {
-                result = new TResult[_length];
+                result = new TSource[_length];
                 Array.Copy(_result, result, _length);
             }
 

--- a/src/Kinetic/Linq/Observable.ToArray.cs
+++ b/src/Kinetic/Linq/Observable.ToArray.cs
@@ -36,6 +36,12 @@ public static partial class Observable
         public StateMachineBox Box =>
             _continuation.Box;
 
+        public StateMachine<TSource> Reference =>
+            StateMachine<TSource>.Create(ref this);
+
+        public StateMachine? Continuation =>
+            _continuation.Reference;
+
         public void Initialize(StateMachineBox box) =>
             _continuation.Initialize(box);
 

--- a/src/Kinetic/Linq/Observable.ToDictionary.cs
+++ b/src/Kinetic/Linq/Observable.ToDictionary.cs
@@ -90,6 +90,12 @@ public static partial class Observable
         public StateMachineBox Box =>
             _continuation.Box;
 
+        public StateMachine<TSource> Reference =>
+            StateMachine<TSource>.Create(ref this);
+
+        public StateMachine? Continuation =>
+            _continuation.Reference;
+
         public void Initialize(StateMachineBox box) =>
             _continuation.Initialize(box);
 

--- a/src/Kinetic/Linq/Observable.ToDictionary.cs
+++ b/src/Kinetic/Linq/Observable.ToDictionary.cs
@@ -62,11 +62,11 @@ public static partial class Observable
         public void Create<TContinuation>(in TContinuation continuation, ObserverStateMachine<TSource> source)
             where TContinuation : struct, IStateMachine<Dictionary<TKey, TValue>>
         {
-            source.ContinueWith(new ToDictionaryStateMachine<TContinuation, TSource, TKey, TValue>(continuation, _keySelector, _valueSelector, _comparer));
+            source.ContinueWith(new ToDictionaryStateMachine<TSource, TKey, TValue, TContinuation>(continuation, _keySelector, _valueSelector, _comparer));
         }
     }
 
-    private struct ToDictionaryStateMachine<TContinuation, TSource, TKey, TValue> : IStateMachine<TSource>
+    private struct ToDictionaryStateMachine<TSource, TKey, TValue, TContinuation> : IStateMachine<TSource>
         where TContinuation : struct, IStateMachine<Dictionary<TKey, TValue>>
         where TKey : notnull
     {

--- a/src/Kinetic/Linq/Observable.ToList.cs
+++ b/src/Kinetic/Linq/Observable.ToList.cs
@@ -36,6 +36,12 @@ public static partial class Observable
         public StateMachineBox Box =>
             _continuation.Box;
 
+        public StateMachine<TSource> Reference =>
+            StateMachine<TSource>.Create(ref this);
+
+        public StateMachine? Continuation =>
+            _continuation.Reference;
+
         public void Initialize(StateMachineBox box) =>
             _continuation.Initialize(box);
 

--- a/src/Kinetic/Linq/Observable.ToList.cs
+++ b/src/Kinetic/Linq/Observable.ToList.cs
@@ -17,11 +17,11 @@ public static partial class Observable
         public void Create<TContinuation>(in TContinuation continuation, ObserverStateMachine<TSource> source)
             where TContinuation : struct, IStateMachine<List<TSource>>
         {
-            source.ContinueWith(new ToListStateMachine<TContinuation, TSource>(continuation));
+            source.ContinueWith(new ToListStateMachine<TSource, TContinuation>(continuation));
         }
     }
 
-    private struct ToListStateMachine<TContinuation, TSource> : IStateMachine<TSource>
+    private struct ToListStateMachine<TSource, TContinuation> : IStateMachine<TSource>
         where TContinuation : struct, IStateMachine<List<TSource>>
     {
         private TContinuation _continuation;

--- a/src/Kinetic/Linq/Observable.Where.cs
+++ b/src/Kinetic/Linq/Observable.Where.cs
@@ -20,11 +20,11 @@ public static partial class Observable
         public void Create<TContinuation>(in TContinuation continuation, ObserverStateMachine<TSource> source)
             where TContinuation : struct, IStateMachine<TSource>
         {
-            source.ContinueWith(new WhereStateMachine<TContinuation, TSource>(continuation, _predicate));
+            source.ContinueWith(new WhereStateMachine<TSource, TContinuation>(continuation, _predicate));
         }
     }
 
-    private struct WhereStateMachine<TContinuation, TSource> : IStateMachine<TSource>
+    private struct WhereStateMachine<TSource, TContinuation> : IStateMachine<TSource>
         where TContinuation : struct, IStateMachine<TSource>
     {
         private TContinuation _continuation;

--- a/src/Kinetic/Linq/Observable.Where.cs
+++ b/src/Kinetic/Linq/Observable.Where.cs
@@ -39,6 +39,12 @@ public static partial class Observable
         public StateMachineBox Box =>
             _continuation.Box;
 
+        public StateMachine<TSource> Reference =>
+            StateMachine<TSource>.Create(ref this);
+
+        public StateMachine? Continuation =>
+            _continuation.Reference;
+
         public void Initialize(StateMachineBox box) =>
             _continuation.Initialize(box);
 

--- a/src/Kinetic/Linq/Observable.WhereAsync.cs
+++ b/src/Kinetic/Linq/Observable.WhereAsync.cs
@@ -35,8 +35,8 @@ public static partial class Observable
             {
                 source.ContinueWith(
                     new WhereAsyncStateMachine<
-                        TContinuation,
                         TSource,
+                        TContinuation,
                         AwaiterForTask<bool>,
                         AwaiterFactoryForTask<TSource, bool>>
                         (continuation, new(taskPredicate)));
@@ -48,8 +48,8 @@ public static partial class Observable
             {
                 source.ContinueWith(
                     new WhereAsyncStateMachine<
-                        TContinuation,
                         TSource,
+                        TContinuation,
                         AwaiterForValueTask<bool>,
                         AwaiterFactoryForValueTask<TSource, bool>>
                         (continuation, new(valueTaskPredicate)));
@@ -61,7 +61,7 @@ public static partial class Observable
         }
     }
 
-    private struct WhereAsyncStateMachine<TContinuation, TSource, TAwaiter, TAwaiterFactory> : IStateMachine<TSource>
+    private struct WhereAsyncStateMachine<TSource, TContinuation, TAwaiter, TAwaiterFactory> : IStateMachine<TSource>
         where TContinuation : struct, IStateMachine<TSource>
         where TAwaiter : struct, IAwaiter<bool>
         where TAwaiterFactory : struct, IAwaiterFactory<TAwaiter, TSource, bool>

--- a/src/Kinetic/Linq/Observable.WhereAsync.cs
+++ b/src/Kinetic/Linq/Observable.WhereAsync.cs
@@ -78,6 +78,12 @@ public static partial class Observable
         public StateMachineBox Box =>
             _continuation.Box;
 
+        public StateMachine<TSource> Reference =>
+            StateMachine<TSource>.Create(ref this);
+
+        public StateMachine? Continuation =>
+            _continuation.Reference;
+
         public void Initialize(StateMachineBox box) =>
             _continuation.Initialize(box);
 

--- a/src/Kinetic/Linq/ObservableView.GroupBy.cs
+++ b/src/Kinetic/Linq/ObservableView.GroupBy.cs
@@ -276,6 +276,12 @@ public static partial class ObservableView
         public StateMachineBox Box =>
             _continuation.Box;
 
+        public StateMachine<ListChange<TSource>> Reference =>
+            StateMachine<ListChange<TSource>>.Create(ref this);
+
+        public StateMachine? Continuation =>
+            _continuation.Reference;
+
         public void Initialize(StateMachineBox box) =>
             _continuation.Initialize(box);
 
@@ -686,6 +692,12 @@ public static partial class ObservableView
 
             public StateMachineBox Box =>
                 _continuation.Box;
+
+            public StateMachine<TKey> Reference =>
+                StateMachines.StateMachine<TKey>.Create(ref this);
+
+            public StateMachine? Continuation =>
+                _continuation.Reference;
 
             public void Initialize(StateMachineBox box) =>
                 _continuation.Initialize(box);

--- a/src/Kinetic/Linq/ObservableView.OnItemAdded.cs
+++ b/src/Kinetic/Linq/ObservableView.OnItemAdded.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using Kinetic.Linq.StateMachines;
 
 namespace Kinetic.Linq;
@@ -6,12 +7,63 @@ namespace Kinetic.Linq;
 public static partial class ObservableView
 {
     public static ObserverBuilder<ListChange<TSource>> OnItemAdded<TSource>(this ObserverBuilder<ListChange<TSource>> source, Action<TSource> action) =>
-        source.Do(change =>
-        {
-            if (change.Action is ListChangeAction.Insert or ListChangeAction.Replace)
-                action(change.NewItem);
-        });
+        source.ContinueWith<OnItemAddedStateMachineFactory<TSource>, ListChange<TSource>>(new() { Action = action });
 
     public static ObserverBuilder<ListChange<TSource>> OnItemAdded<TSource>(this ReadOnlyObservableList<TSource> source, Action<TSource> action) =>
         source.Changed.ToBuilder().OnItemAdded(action);
+
+    private struct OnItemAddedStateMachineFactory<TSource> : IStateMachineFactory<ListChange<TSource>, ListChange<TSource>>
+    {
+        public required Action<TSource> Action { get; init; }
+
+        public void Create<TContinuation>(in TContinuation continuation, ObserverStateMachine<ListChange<TSource>> source)
+            where TContinuation : struct, IStateMachine<ListChange<TSource>>
+        {
+            source.ContinueWith<OnItemAddedStateMachine<TSource, TContinuation>>(new(continuation, Action));
+        }
+    }
+
+    private struct OnItemAddedStateMachine<TSource, TContinuation> : IStateMachine<ListChange<TSource>>
+        where TContinuation : struct, IStateMachine<ListChange<TSource>>
+    {
+        private TContinuation _continuation;
+        private readonly Action<TSource> _action;
+
+        public OnItemAddedStateMachine(in TContinuation continuation, Action<TSource> action)
+        {
+            _continuation = continuation;
+            _action = action;
+        }
+
+        public StateMachineBox Box =>
+            _continuation.Box;
+
+        public StateMachine<ListChange<TSource>> Reference =>
+            _continuation.Reference is IReadOnlyList<TSource> list
+            ? new ListProxyStateMachine<TSource, OnItemAddedStateMachine<TSource, TContinuation>>(ref this, list)
+            : StateMachine<ListChange<TSource>>.Create(ref this);
+
+        public StateMachine? Continuation =>
+            _continuation.Reference;
+
+        public void Initialize(StateMachineBox box) =>
+            _continuation.Initialize(box);
+
+        public void Dispose() =>
+            _continuation.Dispose();
+
+        public void OnCompleted() =>
+            _continuation.OnCompleted();
+
+        public void OnError(Exception error) =>
+            _continuation.OnError(error);
+
+        public void OnNext(ListChange<TSource> value)
+        {
+            if (value.Action is ListChangeAction.Insert or ListChangeAction.Replace)
+                _action(value.NewItem);
+
+            _continuation.OnNext(value);
+        }
+    }
 }

--- a/src/Kinetic/Linq/ObservableView.OrderBy.cs
+++ b/src/Kinetic/Linq/ObservableView.OrderBy.cs
@@ -187,6 +187,24 @@ public static partial class ObservableView
             public StateMachineBox Box =>
                 _continuation.Box;
 
+            StateMachine<ListChange<T>> StateMachines.IStateMachine<ListChange<T>>.Reference =>
+                StateMachine<ListChange<T>>.Create(ref this);
+
+            StateMachine<ValueTuple<TItem>> StateMachines.IStateMachine<ValueTuple<TItem>>.Reference =>
+                StateMachine<ValueTuple<TItem>>.Create(ref this);
+
+            StateMachine<IComparer<TKey>?> StateMachines.IStateMachine<IComparer<TKey>?>.Reference =>
+                StateMachine<IComparer<TKey>?>.Create(ref this);
+
+            StateMachine? StateMachines.IStateMachine<ListChange<T>>.Continuation =>
+                _continuation.Reference;
+
+            StateMachine? StateMachines.IStateMachine<ValueTuple<TItem>>.Continuation =>
+                null;
+
+            StateMachine? StateMachines.IStateMachine<IComparer<TKey>?>.Continuation =>
+                null;
+
             public void Initialize(StateMachineBox box)
             {
                 _continuation.Initialize(box);
@@ -497,6 +515,12 @@ public static partial class ObservableView
 
                 public StateMachineBox Box =>
                     _continuation.Box;
+
+                public StateMachines.StateMachine<TKey> Reference =>
+                    StateMachines.StateMachine<TKey>.Create(ref this);
+
+                public StateMachine? Continuation =>
+                    null;
 
                 public void Initialize(StateMachineBox box) =>
                     _continuation.Initialize(box);

--- a/src/Kinetic/Linq/ObservableView.Select.Async.cs
+++ b/src/Kinetic/Linq/ObservableView.Select.Async.cs
@@ -48,6 +48,18 @@ public static partial class ObservableView
         public StateMachineBox Box =>
             _continuation.Box;
 
+        StateMachine<ListChange<TSource>> IStateMachine<ListChange<TSource>>.Reference =>
+            StateMachine<ListChange<TSource>>.Create(ref this);
+
+        StateMachine<ObservableViewItem<TResult>> IStateMachine<ObservableViewItem<TResult>>.Reference =>
+            StateMachine<ObservableViewItem<TResult>>.Create(ref this);
+
+        StateMachine? IStateMachine<ListChange<TSource>>.Continuation =>
+            _continuation.Reference;
+
+        StateMachine? IStateMachine<ObservableViewItem<TResult>>.Continuation =>
+            null;
+
         public void Initialize(StateMachineBox box) =>
             _continuation.Initialize(box);
 
@@ -257,6 +269,12 @@ public static partial class ObservableView
 
         public StateMachineBox Box =>
             _continuation.Box;
+
+        public StateMachine<T> Reference =>
+            StateMachine<T>.Create(ref this);
+
+        public StateMachine? Continuation =>
+            _continuation.Reference;
 
         public void Initialize(StateMachineBox box) =>
             _continuation.Initialize(box);

--- a/src/Kinetic/Linq/ObservableView.Select.cs
+++ b/src/Kinetic/Linq/ObservableView.Select.cs
@@ -28,6 +28,12 @@ public static partial class ObservableView
         public StateMachineBox Box =>
             _continuation.Box;
 
+        public StateMachine<ListChange<TSource>> Reference =>
+            StateMachine<ListChange<TSource>>.Create(ref this);
+
+        public StateMachine? Continuation =>
+            _continuation.Reference;
+
         public void Initialize(StateMachineBox box) =>
             _continuation.Initialize(box);
 

--- a/src/Kinetic/Linq/ObservableView.Where.Async.cs
+++ b/src/Kinetic/Linq/ObservableView.Where.Async.cs
@@ -48,6 +48,18 @@ public static partial class ObservableView
         public StateMachineBox Box =>
             _continuation.Box;
 
+        StateMachine<ListChange<T>> IStateMachine<ListChange<T>>.Reference =>
+            StateMachine<ListChange<T>>.Create(ref this);
+
+        StateMachine<ObservableViewItem<T>> IStateMachine<ObservableViewItem<T>>.Reference =>
+            StateMachine<ObservableViewItem<T>>.Create(ref this);
+
+        StateMachine? IStateMachine<ListChange<T>>.Continuation =>
+            _continuation.Reference;
+
+        StateMachine? IStateMachine<ObservableViewItem<T>>.Continuation =>
+            null;
+
         public void Initialize(StateMachineBox box) =>
             _continuation.Initialize(box);
 
@@ -246,6 +258,12 @@ public static partial class ObservableView
 
         public StateMachineBox Box =>
             _continuation.Box;
+
+        public StateMachine<bool> Reference =>
+            StateMachine<bool>.Create(ref this);
+
+        public StateMachine? Continuation =>
+            _continuation.Reference;
 
         public void Initialize(StateMachineBox box) =>
             _continuation.Initialize(box);

--- a/src/Kinetic/Linq/ObservableView.Where.cs
+++ b/src/Kinetic/Linq/ObservableView.Where.cs
@@ -27,6 +27,12 @@ public static partial class ObservableView
         public StateMachineBox Box =>
             _continuation.Box;
 
+        public StateMachine<ListChange<T>> Reference =>
+            StateMachine<ListChange<T>>.Create(ref this);
+
+        public StateMachine? Continuation =>
+            _continuation.Reference;
+
         public void Initialize(StateMachineBox box) =>
             _continuation.Initialize(box);
 

--- a/src/Kinetic/Linq/ObservableView.cs
+++ b/src/Kinetic/Linq/ObservableView.cs
@@ -1,4 +1,6 @@
 using System;
+using System.Collections;
+using System.Collections.Generic;
 using Kinetic.Linq.StateMachines;
 
 namespace Kinetic.Linq;
@@ -35,7 +37,7 @@ public class ObservableView<T> : ReadOnlyObservableList<T>, IDisposable
         }
     }
 
-    private struct BindStateMachine<TContinuation> : IStateMachine<ListChange<T>>
+    private struct BindStateMachine<TContinuation> : IStateMachine<ListChange<T>>, IReadOnlyList<T>
         where TContinuation : struct, IStateMachine<ListChange<T>>
     {
         private TContinuation _continuation;
@@ -49,6 +51,18 @@ public class ObservableView<T> : ReadOnlyObservableList<T>, IDisposable
 
         public StateMachineBox Box =>
             _continuation.Box;
+
+        public StateMachine<ListChange<T>> Reference =>
+            new ListStateMachine<T, BindStateMachine<TContinuation>>(ref this);
+
+        public StateMachine? Continuation =>
+            _continuation.Reference;
+
+        public int Count =>
+            _view.Count;
+
+        public T this[int index] =>
+            _view[index];
 
         public void Initialize(StateMachineBox box) =>
             _continuation.Initialize(box);
@@ -87,5 +101,11 @@ public class ObservableView<T> : ReadOnlyObservableList<T>, IDisposable
                     break;
             }
         }
+
+        public IEnumerator<T> GetEnumerator() =>
+            _view.GetEnumerator();
+
+        IEnumerator IEnumerable.GetEnumerator() =>
+            _view.GetEnumerator();
     }
 }

--- a/src/Kinetic/Linq/StateMachines/IStateMachine.cs
+++ b/src/Kinetic/Linq/StateMachines/IStateMachine.cs
@@ -5,6 +5,8 @@ namespace Kinetic.Linq.StateMachines;
 public interface IStateMachine<T> : IObserver<T>, IDisposable
 {
     StateMachineBox Box { get; }
+    StateMachine<T> Reference { get; }
+    StateMachine? Continuation { get; }
 
     void Initialize(StateMachineBox box);
 }

--- a/src/Kinetic/Linq/StateMachines/IStateMachine.cs
+++ b/src/Kinetic/Linq/StateMachines/IStateMachine.cs
@@ -1,0 +1,10 @@
+using System;
+
+namespace Kinetic.Linq.StateMachines;
+
+public interface IStateMachine<T> : IObserver<T>, IDisposable
+{
+    StateMachineBox Box { get; }
+
+    void Initialize(StateMachineBox box);
+}

--- a/src/Kinetic/Linq/StateMachines/IStateMachineBoxFactory.cs
+++ b/src/Kinetic/Linq/StateMachines/IStateMachineBoxFactory.cs
@@ -1,0 +1,7 @@
+namespace Kinetic.Linq.StateMachines;
+
+public interface IStateMachineBoxFactory<TBox>
+{
+    TBox Create<T, TStateMachine>(in TStateMachine stateMachine)
+        where TStateMachine : struct, IStateMachine<T>;
+}

--- a/src/Kinetic/Linq/StateMachines/IStateMachineFactory.cs
+++ b/src/Kinetic/Linq/StateMachines/IStateMachineFactory.cs
@@ -1,0 +1,7 @@
+namespace Kinetic.Linq.StateMachines;
+
+public interface IStateMachineFactory<T, TResult>
+{
+    void Create<TContinuation>(in TContinuation continuation, ObserverStateMachine<T> source)
+        where TContinuation : struct, IStateMachine<TResult>;
+}

--- a/src/Kinetic/Linq/StateMachines/ListProxyStateMachine.cs
+++ b/src/Kinetic/Linq/StateMachines/ListProxyStateMachine.cs
@@ -1,0 +1,28 @@
+using System.Collections;
+using System.Collections.Generic;
+
+namespace Kinetic.Linq.StateMachines;
+
+internal sealed class ListProxyStateMachine<T, TStateMachine> : StateMachine<ListChange<T>, TStateMachine>, IReadOnlyList<T>
+    where TStateMachine : struct, IStateMachine<ListChange<T>>
+{
+    private readonly IReadOnlyList<T> _list;
+
+    public ListProxyStateMachine(ref TStateMachine stateMachine, IReadOnlyList<T> list) :
+        base(ref stateMachine) => _list = list;
+
+    public ListProxyStateMachine(StateMachineReference<ListChange<T>, TStateMachine> stateMachine, IReadOnlyList<T> list) :
+        base(stateMachine) => _list = list;
+
+    public T this[int index] =>
+        _list[index];
+
+    public int Count =>
+        _list.Count;
+
+    public IEnumerator<T> GetEnumerator() =>
+        _list.GetEnumerator();
+
+    IEnumerator IEnumerable.GetEnumerator() =>
+        _list.GetEnumerator();
+}

--- a/src/Kinetic/Linq/StateMachines/ListStateMachine.cs
+++ b/src/Kinetic/Linq/StateMachines/ListStateMachine.cs
@@ -1,0 +1,28 @@
+using System.Collections;
+using System.Collections.Generic;
+
+namespace Kinetic.Linq.StateMachines;
+
+public class ListStateMachine<T, TStateMachine> : StateMachine<ListChange<T>, TStateMachine>, IReadOnlyList<T>
+    where TStateMachine : struct, IStateMachine<ListChange<T>>, IReadOnlyList<T>
+{
+    public ListStateMachine(ref TStateMachine stateMachine) :
+        base(ref stateMachine)
+    { }
+
+    public ListStateMachine(StateMachineReference<ListChange<T>, TStateMachine> stateMachine) :
+        base(stateMachine)
+    { }
+
+    public T this[int index] =>
+        Reference.Target[index];
+
+    public int Count =>
+        Reference.Target.Count;
+
+    public IEnumerator<T> GetEnumerator() =>
+        Reference.Target.GetEnumerator();
+
+    IEnumerator IEnumerable.GetEnumerator() =>
+        Reference.Target.GetEnumerator();
+}

--- a/src/Kinetic/Linq/StateMachines/Observable.Do.cs
+++ b/src/Kinetic/Linq/StateMachines/Observable.Do.cs
@@ -43,11 +43,17 @@ public static partial class Observable
         public StateMachineBox Box =>
             _continuation.Box;
 
-        public void Dispose() =>
-            _continuation.Dispose();
+        public StateMachine<T> Reference =>
+            StateMachine<T>.Create(ref this);
+
+        public StateMachine? Continuation =>
+            _continuation.Reference;
 
         public void Initialize(StateMachineBox box) =>
             _continuation.Initialize(box);
+
+        public void Dispose() =>
+            _continuation.Dispose();
 
         public void OnCompleted()
         {

--- a/src/Kinetic/Linq/StateMachines/Observable.Subscribe.cs
+++ b/src/Kinetic/Linq/StateMachines/Observable.Subscribe.cs
@@ -43,6 +43,12 @@ public static partial class Observable
         public StateMachineBox Box =>
             _box ?? throw new InvalidOperationException();
 
+        public StateMachine<T> Reference =>
+            StateMachine<T>.Create(ref this);
+
+        public StateMachine? Continuation =>
+            null;
+
         public void Initialize(StateMachineBox box) =>
             _box = box;
 

--- a/src/Kinetic/Linq/StateMachines/ObserverStateMachine.cs
+++ b/src/Kinetic/Linq/StateMachines/ObserverStateMachine.cs
@@ -1,0 +1,49 @@
+using System;
+
+namespace Kinetic.Linq.StateMachines;
+
+internal struct ObserverStateMachine<T, TContinuation> : IStateMachine<T>
+    where TContinuation : struct, IStateMachine<T>
+{
+    private TContinuation _continuation;
+    private IObservable<T>? _observable;
+    private IDisposable? _subscription;
+
+    public ObserverStateMachine(in TContinuation continuation, IObservable<T> observable)
+    {
+        _continuation = continuation;
+        _observable = observable;
+        _subscription = null;
+    }
+
+    public StateMachineBox Box =>
+        _continuation.Box;
+
+    public StateMachine<T> Reference =>
+        StateMachine<T>.Create(ref this);
+
+    public StateMachine? Continuation =>
+        _continuation.Reference;
+
+    public void Initialize(StateMachineBox box)
+    {
+        _continuation.Initialize(box);
+        _subscription = _observable?.Subscribe(
+            (StateMachineBox<T, ObserverStateMachine<T, TContinuation>>) box);
+    }
+
+    public void Dispose()
+    {
+        _subscription?.Dispose();
+        _continuation.Dispose();
+    }
+
+    public void OnCompleted() =>
+        _continuation.OnCompleted();
+
+    public void OnError(Exception error) =>
+        _continuation.OnError(error);
+
+    public void OnNext(T value) =>
+        _continuation.OnNext(value);
+}

--- a/src/Kinetic/Linq/StateMachines/ObserverStateMachineFactory.cs
+++ b/src/Kinetic/Linq/StateMachines/ObserverStateMachineFactory.cs
@@ -1,0 +1,15 @@
+using System;
+
+namespace Kinetic.Linq.StateMachines;
+
+internal readonly struct ObserverStateMachineFactory<T> : IStateMachineFactory<T, T>
+{
+    private readonly IObservable<T> _observable;
+
+    public ObserverStateMachineFactory(IObservable<T> observable) =>
+        _observable = observable;
+
+    public void Create<TContinuation>(in TContinuation continuation, StateMachines.ObserverStateMachine<T> source)
+        where TContinuation : struct, IStateMachine<T> =>
+        source.ContinueWith(new ObserverStateMachine<T, TContinuation>(continuation, _observable));
+}

--- a/src/Kinetic/Linq/StateMachines/StateMachine.cs
+++ b/src/Kinetic/Linq/StateMachines/StateMachine.cs
@@ -1,0 +1,43 @@
+using System;
+
+namespace Kinetic.Linq.StateMachines;
+
+public abstract class StateMachine
+{
+    private protected StateMachine() { }
+}
+
+public abstract class StateMachine<T> : StateMachine, IObserver<T>
+{
+    private protected StateMachine() { }
+
+    public abstract void OnCompleted();
+    public abstract void OnError(Exception error);
+    public abstract void OnNext(T value);
+
+    internal static StateMachine<T> Create<TStateMachine>(ref TStateMachine stateMachine)
+        where TStateMachine : struct, IStateMachine<T> =>
+        new StateMachine<T, TStateMachine>(ref stateMachine);
+}
+
+public class StateMachine<T, TStateMachine> : StateMachine<T>
+    where TStateMachine : struct, IStateMachine<T>
+{
+    protected StateMachineReference<T, TStateMachine> Reference { get; }
+
+    public StateMachine(ref TStateMachine stateMachine) :
+        this(new StateMachineReference<T, TStateMachine>(ref stateMachine))
+    { }
+
+    public StateMachine(StateMachineReference<T, TStateMachine> stateMchine) =>
+        Reference = stateMchine;
+
+    public override void OnCompleted() =>
+        Reference.Target.OnCompleted();
+
+    public override void OnError(Exception error) =>
+        Reference.Target.OnError(error);
+
+    public override void OnNext(T value) =>
+        Reference.Target.OnNext(value);
+}

--- a/src/Kinetic/Linq/StateMachines/StateMachineBox.cs
+++ b/src/Kinetic/Linq/StateMachines/StateMachineBox.cs
@@ -4,41 +4,6 @@ using System.Runtime.InteropServices;
 
 namespace Kinetic.Linq.StateMachines;
 
-public interface IStateMachine<T> : IObserver<T>, IDisposable
-{
-    StateMachineBox Box { get; }
-
-    void Initialize(StateMachineBox box);
-}
-
-public interface IStateMachineFactory<T, TResult>
-{
-    void Create<TContinuation>(in TContinuation continuation, ObserverStateMachine<T> source)
-        where TContinuation : struct, IStateMachine<TResult>;
-}
-
-public interface IStateMachineBoxFactory<TBox>
-{
-    TBox Create<T, TStateMachine>(in TStateMachine stateMachine)
-        where TStateMachine : struct, IStateMachine<T>;
-}
-
-public readonly struct StateMachineReference<T, TStateMachine>
-    where TStateMachine : struct, IStateMachine<T>
-{
-    private readonly StateMachineBox _box;
-    private readonly IntPtr _stateMachineOffset;
-
-    public StateMachineReference(ref TStateMachine stateMachine)
-    {
-        _box = stateMachine.Box;
-        _stateMachineOffset = _box.OffsetTo<T, TStateMachine>(ref stateMachine);
-    }
-
-    public ref TStateMachine Target =>
-        ref _box.ReferenceTo<T, TStateMachine>(_stateMachineOffset);
-}
-
 public abstract class StateMachineBox
 {
     private protected abstract ReadOnlySpan<byte> StateMachineData { get; }

--- a/src/Kinetic/Linq/StateMachines/StateMachineReference.cs
+++ b/src/Kinetic/Linq/StateMachines/StateMachineReference.cs
@@ -1,0 +1,29 @@
+using System;
+using System.Diagnostics.CodeAnalysis;
+
+namespace Kinetic.Linq.StateMachines;
+
+public readonly struct StateMachineReference<T, TStateMachine> : IEquatable<StateMachineReference<T, TStateMachine>>
+    where TStateMachine : struct, IStateMachine<T>
+{
+    private readonly StateMachineBox _box;
+    private readonly IntPtr _stateMachineOffset;
+
+    public StateMachineReference(ref TStateMachine stateMachine)
+    {
+        _box = stateMachine.Box;
+        _stateMachineOffset = _box.OffsetTo<T, TStateMachine>(ref stateMachine);
+    }
+
+    public ref TStateMachine Target =>
+        ref _box.ReferenceTo<T, TStateMachine>(_stateMachineOffset);
+
+    public bool Equals(StateMachineReference<T, TStateMachine> other) =>
+        other._box == _box && other._stateMachineOffset == _stateMachineOffset;
+
+    public override bool Equals([NotNullWhen(true)] object? obj) =>
+        obj is StateMachineReference<T, TStateMachine> other && other.Equals(this);
+
+    public override int GetHashCode() =>
+        HashCode.Combine(_box, _stateMachineOffset);
+}

--- a/test/Kinetic.Tests/ObservableViewTests.cs
+++ b/test/Kinetic.Tests/ObservableViewTests.cs
@@ -385,6 +385,7 @@ public class ObservableViewTests
             .Subscribe();
 
         list.Add(0);
+        list.RemoveAt(0);
 
         Assert.True(handledBefore);
         Assert.True(handledAfter);


### PR DESCRIPTION
The idea here is to allow virtual call of state machine methods which are structs and must not be boxed. `StateMachineReference<T, TStateMachine>` done previously cannot be used without specifying the state machine type, so no virtual calls, but `StateMachine<T>` and derived `StateMachine<T, TStateMachine>` provide that feature. Technically, it's a fat pointer, but allocated on the heap with a tiny limitation. To provide additional interfaces there shall be another type derived from `StateMachine<T, TStateMachine>` implementing the required interfaces and routing call to the referenced state machine.

In terms of Rust, it's a poor man's `&dyn Trait` implementation in C#.

The feature should help with building state machines requesting data from their continuations as it's for `OnItemRemoved` due to the lack of `OldItem` property in the `ListChange<T>` type. So, if the follow up state machine can provide all the required data, then there's no need in making snapshots in the current.