### PR TITLE
Unsubscribe observers on error

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,7 +129,7 @@ class Person : ObservableObject
 // person
 // ├ Address
 // │ ├ Observers    Observers = 1
-//   │ └ [0] SubscribeBox
+// │ │ └ [0] SubscribeBox
 // │ └ Value        "Somewhere in the Universe"
 // └ Name
 //   ├ Observers    Observers = 0

--- a/src/Kinetic/Observable.cs
+++ b/src/Kinetic/Observable.cs
@@ -85,11 +85,12 @@ internal struct ObservableSubscriptions<T>
 
     public void OnError(Exception error)
     {
-        var current = Head;
-        while (current is not null)
+        while (Head is { } head)
         {
-            current.OnError(error);
-            current = current.Next;
+            Head = head.Next;
+
+            head.Next = null;
+            head.OnError(error);
         }
     }
 


### PR DESCRIPTION
An error should cause unsubscription of all the connected observers because after that moment the observable is completed and shall produce no events.