### PR TITLE
Removed Subscribe from ReadOnlyObservableList

### DIFF
--- a/src/Kinetic/ObservableList.cs
+++ b/src/Kinetic/ObservableList.cs
@@ -267,9 +267,6 @@ public abstract class ReadOnlyObservableList<T> : ObservableObject, IReadOnlyLis
         }
     }
 
-    public IDisposable Subscribe(IObserver<ListChange<T>> observer) =>
-        EnsureChangeObservable().Subscribe(observer);
-
     private ItemsObservable EnsureChangeObservable() =>
         Unsafe.As<ItemsObservable>(EnsureObservable(GetOffsetOf(ref _items), static (self, offset, next) => new ItemsObservable(self, offset, next)));
 


### PR DESCRIPTION
The method is a duplicate of `Changed.Subscribe` and therefore shouldn't exist.